### PR TITLE
add dragon fetch data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spacex-app",
       "version": "0.1.0",
       "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^1.0.0",
         "@reduxjs/toolkit": "^1.9.7",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/eslint-parser": "^7.22.15",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@babel/plugin-syntax-jsx": "^7.22.5",
         "@babel/preset-react": "^7.22.15",
         "eslint": "^7.32.0",
@@ -657,9 +659,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1895,6 +1905,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
     "redux": "^4.2.1",
+    "@babel/plugin-proposal-private-property-in-object": "^1.0.0",
     "redux-logger": "^3.0.6",
     "web-vitals": "^2.1.4"
   },
@@ -45,6 +46,7 @@
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-syntax-jsx": "^7.22.5",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-react": "^7.22.15",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Rockets />} />
         <Route path="/mission" element={<Mission />} />
-        <Route exact path="/dragons" element={<Dragons />} />
+        <Route path="/Dragons" element={<Dragons />} />
         <Route path="/MyProfile" element={<MyProfile />} />
 
       </Routes>

--- a/src/components/Dragons.js
+++ b/src/components/Dragons.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
-const Dragons = () => (
+const dragons = () => (
   <div>
-    <div>
-      <h2>Dragons</h2>
-    </div>
+    <h2>Dragons</h2>
   </div>
 );
 
-export default Dragons;
+export default dragons;

--- a/src/redux/dragonSlice.js
+++ b/src/redux/dragonSlice.js
@@ -1,15 +1,41 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const initialState = {
+  data: [],
+  isloading: false,
+};
+
+const dragonsApi = 'https://api.spacexdata.com/v4/dragons';
+
+export const fetchdragons = createAsyncThunk('dragon/fetchdragons', async () => {
+  try {
+    const response = await axios.get(dragonsApi);
+    const result = response.data;
+    return result;
+  } catch (err) {
+    throw new Error('Failed to Fetch missions');
+  }
+});
 
 const dragonSlice = createSlice({
   name: 'dragon',
-  initialState: {
-    data: [],
-    loading: false,
-    error: null,
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchdragons.pending, (state) => {
+        state.isloading = true;
+      })
+      .addCase(fetchdragons.fulfilled, (state, action) => {
+        state.isloading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchdragons.rejected, (state) => {
+        state.isloading = false;
+      });
   },
-  reducers: {
-    // We will Add reducers
-  },
+
 });
 
 export default dragonSlice;

--- a/src/redux/dragonSlice.js
+++ b/src/redux/dragonSlice.js
@@ -14,7 +14,7 @@ export const fetchdragons = createAsyncThunk('dragon/fetchdragons', async () => 
     const result = response.data;
     return result;
   } catch (err) {
-    throw new Error('Failed to Fetch missions');
+    throw new Error('Failed to Fetch dragons');
   }
 });
 


### PR DESCRIPTION
## Fetch Dragon data.
Fetch data from the Dragons endpoint  (https://api.spacexdata.com/v3/dragons) when a user navigates to the Dragons section.

Once the data are fetched, dispatch an action to store the selected data in Redux store:

- id
- name
- type
- flickr_images

NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation).